### PR TITLE
Switch back to updated bluetech fork for fuller ES6 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # gulp-ng-annotate-patched
-Fork of [gulp-ng-annotate](https://travis-ci.org/Kagami/gulp-ng-annotate) updated to use [ng-annotate-patched](https://github.com/nevcos/ng-annotate-patched). 
+Fork of [gulp-ng-annotate](https://travis-ci.org/Kagami/gulp-ng-annotate) updated to use [ng-annotate-patched](https://github.com/bluetech/ng-annotate-patched). 
 
-> Add angularjs dependency injection annotations with [ng-annotate-patched](https://github.com/nevcos/ng-annotate-patched) fork with support for ES6 import/export and classes.
+> Add angularjs dependency injection annotations with [ng-annotate-patched](https://github.com/bluetech/ng-annotate-patched) fork with support for ES6 import/export, classes, arrow functions, etc.
 
 ## Install
 

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "dependencies": {
     "bufferstreams": "^1.1.0",
     "merge": "^1.2.0",
-    "ng-annotate-patched": "git+https://github.com/nevcos/ng-annotate-patched.git#es6-class-support",
+    "ng-annotate-patched": "1.11.1",
     "plugin-error": "^0.1.2",
     "through2": "^2.0.1",
     "vinyl-sourcemaps-apply": "^0.2.1"

--- a/test.js
+++ b/test.js
@@ -13,6 +13,8 @@ var BAD_INPUT = 'angular.module("test").directive("foo", function$a, $b) {});';
 var ORIGINAL_ES6 = 'import * as angular from "angular"; angular.module("test"); export class FooController { constructor($a, $b) { "ngInject"; } } m.component("foo", FooController);';
 var TRANSFORMED_ES6 = `import * as angular from "angular"; angular.module("test"); export class FooController { constructor($a, $b) { "ngInject"; } }
 FooController.$inject = ["$a", "$b"]; m.component("foo", FooController);`;
+var ORIGINAL_ARROW = 'angular.module("test"); m.directive("foo", ($a, $b) => {});'
+var TRANSFORMED_ARROW = 'angular.module("test"); m.directive("foo", ["$a", "$b", ($a, $b) => {}]);';
 
 describe("gulp-ng-annotate", function() {
   it("should annotate angular declarations", function (done) {
@@ -129,6 +131,17 @@ describe("gulp-ng-annotate-patched", function() {
     });
 
     stream.write(new Vinyl({contents: new Buffer(ORIGINAL_ES6)}));
+  });
+
+  it("should annotate ES6 arrow functions", function (done) {
+    var stream = ngAnnotate();
+
+    stream.on("data", function (data) {
+      assert.equal(data.contents.toString(), TRANSFORMED_ARROW);
+      done();
+    });
+
+    stream.write(new Vinyl({contents: new Buffer(ORIGINAL_ARROW)}));
   });
 
 });


### PR DESCRIPTION
The fork-of-a-fork that this plugin is based on is now lagging behind its parent repo by some 40 commits. I propose that we switch this project back to using the original `bluetech` fork, which is now the most advanced version of `ng-annotate-patched`.

Everything from `nevcos` seems to have been merged there as well, so this won't remove any functionality.

It will allow the use of arrow functions in the source (test included).